### PR TITLE
Move @cucumber/messages to dev dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
             "license": "MIT",
             "dependencies": {
                 "@cucumber/gherkin": "^39.0.0",
-                "@cucumber/messages": "^32.3.1",
                 "ansi-colors": "^4.1.3",
                 "axios": "^1.15.2",
                 "form-data": "^4.0.5",
@@ -19,6 +18,7 @@
             "devDependencies": {
                 "@badeball/cypress-cucumber-preprocessor": "^24.0.1",
                 "@bahmutov/cypress-esbuild-preprocessor": "^2.2.8",
+                "@cucumber/messages": "^32.3.1",
                 "@eslint/js": "^10.0.1",
                 "@faker-js/faker": "^10.4.0",
                 "@qytera/xray-client": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     },
     "dependencies": {
         "@cucumber/gherkin": "^39.0.0",
-        "@cucumber/messages": "^32.3.1",
         "ansi-colors": "^4.1.3",
         "axios": "^1.15.2",
         "form-data": "^4.0.5",
@@ -65,6 +64,7 @@
     "devDependencies": {
         "@badeball/cypress-cucumber-preprocessor": "^24.0.1",
         "@bahmutov/cypress-esbuild-preprocessor": "^2.2.8",
+        "@cucumber/messages": "^32.3.1",
         "@eslint/js": "^10.0.1",
         "@faker-js/faker": "^10.4.0",
         "@qytera/xray-client": "^4.0.0",

--- a/src/plugin/feature-file-processing/gherkin.ts
+++ b/src/plugin/feature-file-processing/gherkin.ts
@@ -1,6 +1,5 @@
 import { AstBuilder, GherkinClassicTokenMatcher, Parser } from "@cucumber/gherkin";
 import type { GherkinDocument } from "@cucumber/messages";
-import { IdGenerator } from "@cucumber/messages";
 import fs from "fs";
 
 /**
@@ -18,9 +17,18 @@ export function parseFeatureFile(
     file: string,
     encoding: BufferEncoding = "utf-8"
 ): GherkinDocument {
-    const uuidFn = IdGenerator.uuid();
-    const builder = new AstBuilder(uuidFn);
+    const builder = new AstBuilder(idGenerator());
     const matcher = new GherkinClassicTokenMatcher();
     const parser = new Parser(builder, matcher);
     return parser.parse(fs.readFileSync(file, { encoding: encoding }));
+}
+
+/**
+ * See: https://github.com/cucumber/messages/blob/134afe9532a951b14527b30f0dbf3065c7f47e5f/javascript/src/IdGenerator.ts
+ */
+function idGenerator(): () => string {
+    let next = 0;
+    return () => {
+        return (next++).toString();
+    };
 }


### PR DESCRIPTION
It's almost exclusively being used for type hints and I'd like to keep the supply chain attack surface as small as possible.